### PR TITLE
`apt.sw.be` is broken

### DIFF
--- a/manifests/repo/repoforge.pp
+++ b/manifests/repo/repoforge.pp
@@ -8,7 +8,7 @@ class yum::repo::repoforge {
 
   yum::managed_yumrepo { 'repoforge':
     descr         => 'RepoForge packages',
-    baseurl       => "http://apt.sw.be/redhat/el${osver[0]}/en/\$basearch/rpmforge",
+    baseurl       => "http://repository.it4i.cz/mirrors/repoforge/redhat/el${osver[0]}/en/$basearch/rpmforge",
     enabled       => 1,
     gpgcheck      => 1,
     gpgkey        => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',

--- a/manifests/repo/repoforgeextras.pp
+++ b/manifests/repo/repoforgeextras.pp
@@ -1,14 +1,14 @@
 # = Class: yum::repo::repoforgeextras
 #
 # This class installs the repoforge extras repo
-#
+# 
 class yum::repo::repoforgeextras {
 
   $osver = split($::operatingsystemrelease, '[.]')
 
   yum::managed_yumrepo { 'repoforgeextras':
     descr    => 'RepoForge extra packages',
-    baseurl  => "http://apt.sw.be/redhat/el${osver[0]}/en/\$basearch/extras",
+    baseurl  => "http://repository.it4i.cz/mirrors/repoforge/redhat/el${osver[0]}/en/\$basearch/extras",
     enabled  => 1,
     gpgcheck => 1,
     gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',

--- a/manifests/repo/rpmforge.pp
+++ b/manifests/repo/rpmforge.pp
@@ -6,16 +6,16 @@ class yum::repo::rpmforge {
 $osver = split($::operatingsystemrelease, '[.]')
   case $osver[0] {
     '7': {
-      $baseurl = 'http://apt.sw.be/redhat/el7/en/$basearch/rpmforge'
-      $mirrorlist = 'http://apt.sw.be/redhat/el7/en/mirrors-rpmforge'
+      $baseurl = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el7/en/$basearch/rpmforge'
+      $mirrorlist = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el7/en/mirrors-rpmforge'
     }
     '6': {
-      $baseurl = 'http://apt.sw.be/redhat/el6/en/$basearch/rpmforge'
-      $mirrorlist = 'http://apt.sw.be/redhat/el6/en/mirrors-rpmforge'
+      $baseurl = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el6/en/$basearch/rpmforge'
+      $mirrorlist = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el6/en/mirrors-rpmforge'
     }
     '5': {
-      $baseurl = 'http://apt.sw.be/redhat/el5/en/$basearch/rpmforge'
-      $mirrorlist = 'http://apt.sw.be/redhat/el5/en/mirrors-rpmforge'
+      $baseurl = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el5/en/$basearch/rpmforge'
+      $mirrorlist = 'http://repository.it4i.cz/mirrors/repoforge/redhat/el5/en/mirrors-rpmforge'
     }
     default: { fail('Unsupported version of Enterprise Linux') }
   }


### PR DESCRIPTION
### I see that a PR has already been setup for this problem: https://github.com/puphpet/puppet-yum/pull/1. Feel free to close it if you want.

I am not sure if these modules were still in use, but when I provision puphpet, I get errors such as this (one for almost every package to install):

```
==> Site1: Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install yum-plugin-priorities' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: rpmforge. Please verify its path and try again
==> Site1: Could not retrieve mirrorlist http://apt.sw.be/redhat/el6/en/mirrors-rpmforge error was
==> Site1: 14: PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
==> Site1: Error: /Stage[main]/Yum::Prerequisites/Yum::Plugin[priorities]/Package[yum-plugin-priorities]/ensure: change from purged to present failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install yum-plugin-priorities' returned 1: Error: Cannot retrieve repository metadata (repomd.xml) for repository: rpmforge. Please verify its path and try again
==> Site1: Could not retrieve mirrorlist http://apt.sw.be/redhat/el6/en/mirrors-rpmforge error was
==> Site1: 14: PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
```

I traced it back to the files that I have modified. This mirror or location for the repositories does not work. By updating to this mirror (or if you have a better one), my puphpet instance was able to load once again.
